### PR TITLE
feat(servers): add mercury-pubfinance MCP server

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -9,7 +9,7 @@
   {
     "name": "mercury-darth-feedor",
     "label": "Darth Feedor",
-    "description": "Financial articles, squawk context, and research — progressive retrieval, filtered views",
+    "description": "Financial articles, squawk context, and research \u2014 progressive retrieval, filtered views",
     "url": "https://mcp.mercuryintelligence.net/feeder/mcp",
     "transport": "http"
   },
@@ -18,6 +18,13 @@
     "label": "Economic Calendar",
     "description": "Macro events, economic releases, central bank decisions",
     "url": "https://mcp.mercuryintelligence.net/econ/mcp",
+    "transport": "http"
+  },
+  {
+    "name": "mercury-pubfinance",
+    "label": "Public Finance",
+    "description": "Fed reference rates (SOFR, EFFR, OBFR), repo/RRP operations, Treasury auctions, TGA, primary dealers, fiscal flows",
+    "url": "https://mcp.mercuryintelligence.net/pubfinance/mcp",
     "transport": "http"
   }
 ]


### PR DESCRIPTION
## Summary

- Adds `mercury-pubfinance` to the installer server registry (`servers.json`)
- Route: `mcp.mercuryintelligence.net/pubfinance/mcp`
- Container `pubfinance-mcp` is live and healthy in treasury-cb stack

## Tools exposed via MCP

Fed reference rates (SOFR, EFFR, OBFR, BGCR, TGCR), repo/RRP operations, Treasury auctions & calendar, TGA balance, primary dealer positions, fiscal flows, FX basis, LCI, financial stress index.

## Test plan

- [ ] `npx mercury-install-mcp` → pubfinance appears in server list
- [ ] Install pubfinance → Claude Code connects to `mcp.mercuryintelligence.net/pubfinance/mcp`
- [ ] MCP tools respond correctly (reference rates, repo, auctions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)