### PR TITLE
fix(security): consolidated Codex audit fixes (P1 + P2)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -8,22 +8,20 @@ PROTECTED_BRANCHES="main master"
 remote="${1:-origin}"
 
 while read -r local_ref local_sha remote_ref remote_sha; do
+    # Block by destination ref — covers `git push origin HEAD:main` etc.
     branch="${remote_ref#refs/heads/}"
     for protected in $PROTECTED_BRANCHES; do
         if [ "$branch" = "$protected" ]; then
-            current=$(git rev-parse --abbrev-ref HEAD)
-            if [ "$current" = "$protected" ]; then
-                echo "🚫 Direct push to '$protected' blocked." >&2
-                echo "" >&2
-                echo "Open a PR instead:" >&2
-                echo "  git checkout -b feature/<id>-<slug>" >&2
-                echo "  git push -u origin <branch>" >&2
-                echo "  gh pr create --fill" >&2
-                echo "  gh pr merge --auto --squash --delete-branch" >&2
-                echo "" >&2
-                echo "Bypass (emergency only):  git push --no-verify" >&2
-                exit 1
-            fi
+            echo "🚫 Direct push to '$protected' blocked." >&2
+            echo "" >&2
+            echo "Open a PR instead:" >&2
+            echo "  git checkout -b feature/<id>-<slug>" >&2
+            echo "  git push -u origin <branch>" >&2
+            echo "  gh pr create --fill" >&2
+            echo "  gh pr merge --auto --squash --delete-branch" >&2
+            echo "" >&2
+            echo "Bypass (emergency only):  git push --no-verify" >&2
+            exit 1
         fi
     done
 done < /dev/stdin

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -5,6 +5,8 @@ name: OSV Scanner
 # Scans manifests + lockfiles against the OSV.dev database.
 
 on:
+  push:
+    branches: [main, master]    # scan immediately after every merge
   pull_request:
     branches: [main, master]
   schedule:

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -16,8 +16,14 @@ regexes = [
 paths = [
     # Local secrets (gitignored — never committed). The --no-git scan walks
     # the filesystem so these get visited; in CI git history they don't exist.
+    # NOTE: narrow patterns only — never blanket-allowlist .env.* because
+    # tracked files like .env.production with real credentials would be ignored.
     '''^\.env$''',
-    '''^\.env\..*''',
+    '''^\.env\.local$''',
+    '''^\.env\.development\.local$''',
+    '''^\.env\.test\.local$''',
+    '''^\.env\.production\.local$''',
+    '''^\.env\.example$''',
 
     # Beads issue tracker — JSONL exports of issues + memories.
     # High-entropy strings (memory keys, dolt commit hashes) trip generic-api-key.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,4 +64,4 @@ repos:
         pass_filenames: false
         # Skips silently if osv-scanner is not installed locally —
         # CI will catch it. To install: go install github.com/google/osv-scanner/cmd/osv-scanner@latest
-        entry: bash -c 'command -v osv-scanner >/dev/null && osv-scanner --recursive --skip-git ./ || echo "osv-scanner not installed locally — skipping (CI covers it)"'
+        entry: bash -c 'if command -v osv-scanner >/dev/null; then osv-scanner --recursive ./; else echo "osv-scanner not installed locally — skipping (CI covers it)"; fi'

--- a/.xtrm/skills/default/security-pipeline/scripts/security-bootstrap.sh
+++ b/.xtrm/skills/default/security-pipeline/scripts/security-bootstrap.sh
@@ -53,10 +53,12 @@ git checkout -b "$BRANCH" 2>/dev/null || git checkout "$BRANCH"
 # ── 3. Copy files (conflict-aware) ────────────────────────────────────────
 copy_file() {
     local rel="$1"
-    local src="$SOURCE/$rel"
+    # Try templates/ first (skill layout), then SOURCE root (mercury-infra layout)
+    local src="$SOURCE/templates/$rel"
+    [ -f "$src" ] || src="$SOURCE/$rel"
     local dst="$TARGET/$rel"
     if [ ! -f "$src" ]; then
-        echo "  ⚠️  source missing: $rel"
+        echo "  ⚠️  source missing: $rel (looked in templates/ and root)"
         return
     fi
     mkdir -p "$(dirname "$dst")"
@@ -181,12 +183,31 @@ EOF
     echo "  + .github/dependabot.yml ($(echo "${ECOSYSTEMS[*]}" | wc -w) ecosystems)"
 fi
 
-# ── 5. .githooks/pre-push (only if .githooks dir exists) ──────────────────
-if [ -d "$TARGET/.githooks" ]; then
-    echo "  ⚠️  .githooks/ exists — manually merge anti-direct-push logic from $SOURCE/.githooks/pre-push"
+# ── 5. .githooks/pre-push (merge baseline if existing, install if absent) ──
+# Source candidates: templates/.githooks/pre-push.template (skill) OR .githooks/pre-push (mercury-infra)
+PREPUSH_SRC=""
+for cand in "$SOURCE/templates/.githooks/pre-push.template" "$SOURCE/.githooks/pre-push"; do
+    [ -f "$cand" ] && PREPUSH_SRC="$cand" && break
+done
+if [ -z "$PREPUSH_SRC" ]; then
+    echo "  ⚠️  no pre-push baseline found; skipping hooks"
+elif [ -f "$TARGET/.githooks/pre-push" ]; then
+    # Append baseline with idempotency marker so we don't double-inject
+    if ! grep -q "security-pipeline-baseline" "$TARGET/.githooks/pre-push" 2>/dev/null; then
+        {
+            echo ""
+            echo "# >>> security-pipeline-baseline (managed by security-bootstrap.sh) >>>"
+            cat "$PREPUSH_SRC"
+            echo "# <<< security-pipeline-baseline <<<"
+        } >> "$TARGET/.githooks/pre-push"
+        chmod +x "$TARGET/.githooks/pre-push"
+        echo "  + .githooks/pre-push (appended baseline to existing)"
+    else
+        echo "  ✓ .githooks/pre-push (baseline already present)"
+    fi
 else
     mkdir -p "$TARGET/.githooks"
-    cp "$SOURCE/.githooks/pre-push" "$TARGET/.githooks/pre-push"
+    cp "$PREPUSH_SRC" "$TARGET/.githooks/pre-push"
     chmod +x "$TARGET/.githooks/pre-push"
     echo "  + .githooks/pre-push"
 fi

--- a/.xtrm/skills/default/security-pipeline/templates/.githooks/pre-push.template
+++ b/.xtrm/skills/default/security-pipeline/templates/.githooks/pre-push.template
@@ -8,22 +8,20 @@ PROTECTED_BRANCHES="main master"
 remote="${1:-origin}"
 
 while read -r local_ref local_sha remote_ref remote_sha; do
+    # Block by destination ref — covers `git push origin HEAD:main` etc.
     branch="${remote_ref#refs/heads/}"
     for protected in $PROTECTED_BRANCHES; do
         if [ "$branch" = "$protected" ]; then
-            current=$(git rev-parse --abbrev-ref HEAD)
-            if [ "$current" = "$protected" ]; then
-                echo "🚫 Direct push to '$protected' blocked." >&2
-                echo "" >&2
-                echo "Open a PR instead:" >&2
-                echo "  git checkout -b feature/<id>-<slug>" >&2
-                echo "  git push -u origin <branch>" >&2
-                echo "  gh pr create --fill" >&2
-                echo "  gh pr merge --auto --squash --delete-branch" >&2
-                echo "" >&2
-                echo "Bypass (emergency only):  git push --no-verify" >&2
-                exit 1
-            fi
+            echo "🚫 Direct push to '$protected' blocked." >&2
+            echo "" >&2
+            echo "Open a PR instead:" >&2
+            echo "  git checkout -b feature/<id>-<slug>" >&2
+            echo "  git push -u origin <branch>" >&2
+            echo "  gh pr create --fill" >&2
+            echo "  gh pr merge --auto --squash --delete-branch" >&2
+            echo "" >&2
+            echo "Bypass (emergency only):  git push --no-verify" >&2
+            exit 1
         fi
     done
 done < /dev/stdin

--- a/.xtrm/skills/default/security-pipeline/templates/.github/workflows/osv-scanner.yml
+++ b/.xtrm/skills/default/security-pipeline/templates/.github/workflows/osv-scanner.yml
@@ -5,6 +5,8 @@ name: OSV Scanner
 # Scans manifests + lockfiles against the OSV.dev database.
 
 on:
+  push:
+    branches: [main, master]    # scan immediately after every merge
   pull_request:
     branches: [main, master]
   schedule:

--- a/.xtrm/skills/default/security-pipeline/templates/.gitleaks.toml
+++ b/.xtrm/skills/default/security-pipeline/templates/.gitleaks.toml
@@ -16,8 +16,14 @@ regexes = [
 paths = [
     # Local secrets (gitignored — never committed). The --no-git scan walks
     # the filesystem so these get visited; in CI git history they don't exist.
+    # NOTE: narrow patterns only — never blanket-allowlist .env.* because
+    # tracked files like .env.production with real credentials would be ignored.
     '''^\.env$''',
-    '''^\.env\..*''',
+    '''^\.env\.local$''',
+    '''^\.env\.development\.local$''',
+    '''^\.env\.test\.local$''',
+    '''^\.env\.production\.local$''',
+    '''^\.env\.example$''',
 
     # Beads issue tracker — JSONL exports of issues + memories.
     # High-entropy strings (memory keys, dolt commit hashes) trip generic-api-key.

--- a/.xtrm/skills/default/security-pipeline/templates/.pre-commit-config.yaml
+++ b/.xtrm/skills/default/security-pipeline/templates/.pre-commit-config.yaml
@@ -64,4 +64,4 @@ repos:
         pass_filenames: false
         # Skips silently if osv-scanner is not installed locally —
         # CI will catch it. To install: go install github.com/google/osv-scanner/cmd/osv-scanner@latest
-        entry: bash -c 'command -v osv-scanner >/dev/null && osv-scanner --recursive --skip-git ./ || echo "osv-scanner not installed locally — skipping (CI covers it)"'
+        entry: bash -c 'if command -v osv-scanner >/dev/null; then osv-scanner --recursive ./; else echo "osv-scanner not installed locally — skipping (CI covers it)"; fi'

--- a/.xtrm/skills/default/security-pipeline/templates/scripts/semgrep-diff.sh
+++ b/.xtrm/skills/default/security-pipeline/templates/scripts/semgrep-diff.sh
@@ -10,8 +10,26 @@ if ! command -v semgrep >/dev/null; then
     exit 0
 fi
 
-git fetch origin main --quiet 2>/dev/null || true
-BASE=$(git merge-base HEAD origin/main 2>/dev/null || git rev-parse HEAD~1)
+# Derive base ref dynamically: prefer the branch's tracked upstream, fall back
+# to common default branches, finally to HEAD~N where N covers the whole push.
+upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)
+if [ -n "$upstream" ]; then
+    BASE_REF="$upstream"
+else
+    BASE_REF=""
+    for cand in origin/main origin/master main master; do
+        git rev-parse --verify "$cand" >/dev/null 2>&1 && BASE_REF="$cand" && break
+    done
+fi
+
+[ -n "$BASE_REF" ] && git fetch "${BASE_REF%%/*}" "${BASE_REF#*/}" --quiet 2>/dev/null || true
+
+if [ -n "$BASE_REF" ]; then
+    BASE=$(git merge-base HEAD "$BASE_REF" 2>/dev/null || true)
+fi
+# Final fallback: walk back enough to cover the entire push (find common
+# ancestor across N revs; default 50 if no remote tracking)
+[ -z "${BASE:-}" ] && BASE=$(git rev-list HEAD --max-count=50 | tail -1)
 
 exec semgrep scan \
     --config=p/default \

--- a/scripts/semgrep-diff.sh
+++ b/scripts/semgrep-diff.sh
@@ -10,8 +10,26 @@ if ! command -v semgrep >/dev/null; then
     exit 0
 fi
 
-git fetch origin main --quiet 2>/dev/null || true
-BASE=$(git merge-base HEAD origin/main 2>/dev/null || git rev-parse HEAD~1)
+# Derive base ref dynamically: prefer the branch's tracked upstream, fall back
+# to common default branches, finally to HEAD~N where N covers the whole push.
+upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)
+if [ -n "$upstream" ]; then
+    BASE_REF="$upstream"
+else
+    BASE_REF=""
+    for cand in origin/main origin/master main master; do
+        git rev-parse --verify "$cand" >/dev/null 2>&1 && BASE_REF="$cand" && break
+    done
+fi
+
+[ -n "$BASE_REF" ] && git fetch "${BASE_REF%%/*}" "${BASE_REF#*/}" --quiet 2>/dev/null || true
+
+if [ -n "$BASE_REF" ]; then
+    BASE=$(git merge-base HEAD "$BASE_REF" 2>/dev/null || true)
+fi
+# Final fallback: walk back enough to cover the entire push (find common
+# ancestor across N revs; default 50 if no remote tracking)
+[ -z "${BASE:-}" ] && BASE=$(git rev-list HEAD --max-count=50 | tail -1)
 
 exec semgrep scan \
     --config=p/default \


### PR DESCRIPTION
Address findings from Codex inline reviews on the security pipeline rollout:

P1 (gate-blocking bugs):
- .pre-commit-config.yaml: osv-scanner pre-push entry was 'cmd && X || echo'
  which converted any non-zero exit (including real findings) into success.
  Push gate was silently bypassed. Now uses if/else to distinguish 'not
  installed' from 'scan failed'.
- .gitleaks.toml: '.env\..*' regex was a blanket allowlist hiding real
  secrets in tracked files like .env.production. Narrowed to local-only
  patterns: .env, .env.local, .env.*.local, .env.example.
- scripts/security-bootstrap.sh: copy_file resolved sources from $SOURCE root,
  but skill ships templates under templates/. Now tries templates/ first,
  falls back to root. Also: pre-push merge logic — if .githooks/pre-push
  exists, append baseline with idempotency marker; otherwise install.
  Reads pre-push.template (skill name) as fallback to .githooks/pre-push.

P2 (regressions / coverage gaps):
- .github/workflows/osv-scanner.yml: restored push:[main,master] trigger.
  Previous removal created a coverage gap — vulns from merges/admin pushes
  deferred to weekly cron. OSV scan is fast and has no 'pre-existing debt'
  issue (unlike semgrep), so push trigger is appropriate.
- .githooks/pre-push: protected-branch guard checked HEAD instead of
  remote_ref, so 'git push origin HEAD:main' bypassed it. Now keys off
  destination ref directly.
- scripts/semgrep-diff.sh: hard-coded origin/main as baseline. Now derives
  from current branch's tracked upstream, falling back to common defaults,
  finally walking back HEAD~50 if no remote tracking exists. Multi-commit
  pushes no longer skip earlier commits.

All fixes propagated to mercury-infra, .xtrm/skills/default/security-pipeline/
templates, and 10 sibling Mercury repos (and xtrm-tools as skill source).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
