### PR TITLE
fix(security): wrapper-pattern pre-push merge + semgrep-diff baseline guard

### DIFF
--- a/.xtrm/skills/default/security-pipeline/scripts/security-bootstrap.sh
+++ b/.xtrm/skills/default/security-pipeline/scripts/security-bootstrap.sh
@@ -183,33 +183,58 @@ EOF
     echo "  + .github/dependabot.yml ($(echo "${ECOSYSTEMS[*]}" | wc -w) ecosystems)"
 fi
 
-# ── 5. .githooks/pre-push (merge baseline if existing, install if absent) ──
-# Source candidates: templates/.githooks/pre-push.template (skill) OR .githooks/pre-push (mercury-infra)
+# ── 5. .githooks/pre-push (install wrapper if existing, install baseline if absent) ──
+# Codex-audit-driven design (do NOT regress): existing pre-push hooks may
+#   (a) end with `exit 0` — appending baseline makes it unreachable
+#   (b) read stdin (push refs) — single-pass, baseline would see EOF
+# Solution: when a pre-push exists, move it to pre-push.local and install a
+# managed wrapper that runs baseline FIRST (preserving stdin via tee) and
+# then re-feeds stdin to pre-push.local.
 PREPUSH_SRC=""
 for cand in "$SOURCE/templates/.githooks/pre-push.template" "$SOURCE/.githooks/pre-push"; do
     [ -f "$cand" ] && PREPUSH_SRC="$cand" && break
 done
 if [ -z "$PREPUSH_SRC" ]; then
     echo "  ⚠️  no pre-push baseline found; skipping hooks"
-elif [ -f "$TARGET/.githooks/pre-push" ]; then
-    # Append baseline with idempotency marker so we don't double-inject
-    if ! grep -q "security-pipeline-baseline" "$TARGET/.githooks/pre-push" 2>/dev/null; then
-        {
-            echo ""
-            echo "# >>> security-pipeline-baseline (managed by security-bootstrap.sh) >>>"
-            cat "$PREPUSH_SRC"
-            echo "# <<< security-pipeline-baseline <<<"
-        } >> "$TARGET/.githooks/pre-push"
-        chmod +x "$TARGET/.githooks/pre-push"
-        echo "  + .githooks/pre-push (appended baseline to existing)"
-    else
-        echo "  ✓ .githooks/pre-push (baseline already present)"
-    fi
 else
     mkdir -p "$TARGET/.githooks"
-    cp "$PREPUSH_SRC" "$TARGET/.githooks/pre-push"
+    BASELINE="$TARGET/.githooks/.security-pipeline-baseline"
+    cp "$PREPUSH_SRC" "$BASELINE"
+    chmod +x "$BASELINE"
+    if [ -f "$TARGET/.githooks/pre-push" ] && ! grep -q "security-pipeline-managed-wrapper" "$TARGET/.githooks/pre-push" 2>/dev/null; then
+        # Existing hook present and not yet our wrapper — move it aside
+        mv "$TARGET/.githooks/pre-push" "$TARGET/.githooks/pre-push.local"
+        chmod +x "$TARGET/.githooks/pre-push.local"
+        echo "  ↪ existing .githooks/pre-push moved to pre-push.local"
+    fi
+    cat > "$TARGET/.githooks/pre-push" <<'WRAPEOF'
+#!/usr/bin/env bash
+# security-pipeline-managed-wrapper — installed by security-bootstrap.sh
+# Runs the security baseline first, then any user-local pre-push hook.
+# Both receive the original push refs on stdin.
+set -uo pipefail
+
+REFS=$(cat)
+HOOKS_DIR=$(dirname "$0")
+
+# 1. Baseline: anti-direct-main + pre-commit pre-push chain
+if [ -x "$HOOKS_DIR/.security-pipeline-baseline" ]; then
+    echo "$REFS" | "$HOOKS_DIR/.security-pipeline-baseline" "$@"
+    rc=$?
+    [ $rc -ne 0 ] && exit $rc
+fi
+
+# 2. User-local hook (preserves any pre-existing logic)
+if [ -x "$HOOKS_DIR/pre-push.local" ]; then
+    echo "$REFS" | "$HOOKS_DIR/pre-push.local" "$@"
+    rc=$?
+    [ $rc -ne 0 ] && exit $rc
+fi
+
+exit 0
+WRAPEOF
     chmod +x "$TARGET/.githooks/pre-push"
-    echo "  + .githooks/pre-push"
+    echo "  + .githooks/pre-push (managed wrapper) + .security-pipeline-baseline"
 fi
 
 # ── 6. Commit + PR ────────────────────────────────────────────────────────

--- a/.xtrm/skills/default/security-pipeline/templates/scripts/semgrep-diff.sh
+++ b/.xtrm/skills/default/security-pipeline/templates/scripts/semgrep-diff.sh
@@ -27,9 +27,20 @@ fi
 if [ -n "$BASE_REF" ]; then
     BASE=$(git merge-base HEAD "$BASE_REF" 2>/dev/null || true)
 fi
-# Final fallback: walk back enough to cover the entire push (find common
-# ancestor across N revs; default 50 if no remote tracking)
-[ -z "${BASE:-}" ] && BASE=$(git rev-list HEAD --max-count=50 | tail -1)
+# Final fallback: walk back enough to cover the push. On a single-commit
+# history rev-list returns HEAD itself — using HEAD as baseline produces an
+# empty diff and silently misses everything. Refuse that case and run a
+# full scan instead so first-push coverage stays honest.
+if [ -z "${BASE:-}" ]; then
+    BASE=$(git rev-list HEAD --max-count=50 | tail -1)
+fi
+HEAD_SHA=$(git rev-parse HEAD)
+SEMGREP_BASELINE_ARGS=()
+if [ -n "${BASE:-}" ] && [ "$BASE" != "$HEAD_SHA" ]; then
+    SEMGREP_BASELINE_ARGS=(--baseline-commit="$BASE")
+else
+    echo "[semgrep-diff] no usable baseline (single-commit branch?) — running full scan"
+fi
 
 exec semgrep scan \
     --config=p/default \
@@ -38,7 +49,7 @@ exec semgrep scan \
     --config=p/python \
     --config=p/dockerfile \
     --config=p/github-actions \
-    --baseline-commit="$BASE" \
+    "${SEMGREP_BASELINE_ARGS[@]}" \
     --error \
     --quiet \
     --skip-unknown-extensions

--- a/scripts/semgrep-diff.sh
+++ b/scripts/semgrep-diff.sh
@@ -27,9 +27,20 @@ fi
 if [ -n "$BASE_REF" ]; then
     BASE=$(git merge-base HEAD "$BASE_REF" 2>/dev/null || true)
 fi
-# Final fallback: walk back enough to cover the entire push (find common
-# ancestor across N revs; default 50 if no remote tracking)
-[ -z "${BASE:-}" ] && BASE=$(git rev-list HEAD --max-count=50 | tail -1)
+# Final fallback: walk back enough to cover the push. On a single-commit
+# history rev-list returns HEAD itself — using HEAD as baseline produces an
+# empty diff and silently misses everything. Refuse that case and run a
+# full scan instead so first-push coverage stays honest.
+if [ -z "${BASE:-}" ]; then
+    BASE=$(git rev-list HEAD --max-count=50 | tail -1)
+fi
+HEAD_SHA=$(git rev-parse HEAD)
+SEMGREP_BASELINE_ARGS=()
+if [ -n "${BASE:-}" ] && [ "$BASE" != "$HEAD_SHA" ]; then
+    SEMGREP_BASELINE_ARGS=(--baseline-commit="$BASE")
+else
+    echo "[semgrep-diff] no usable baseline (single-commit branch?) — running full scan"
+fi
 
 exec semgrep scan \
     --config=p/default \
@@ -38,7 +49,7 @@ exec semgrep scan \
     --config=p/python \
     --config=p/dockerfile \
     --config=p/github-actions \
-    --baseline-commit="$BASE" \
+    "${SEMGREP_BASELINE_ARGS[@]}" \
     --error \
     --quiet \
     --skip-unknown-extensions


### PR DESCRIPTION
Codex audit on PR #32 wave found two P1/P2 regressions in the previous fix:

P1: Bootstrap append-after-existing was unreachable when target pre-push
ended with 'exit 0' (common). Also, pre-push reads stdin (push refs) which
is single-pass — if existing hook consumed it, appended baseline saw EOF
and never enforced anti-direct-main. Fix: install a managed wrapper as
.githooks/pre-push that runs the baseline first then any user-local logic
(.githooks/pre-push.local). Both receive the original push refs replayed
via stdin ($REFS=$(cat)). Existing pre-push is moved to pre-push.local on
first run; idempotent via 'security-pipeline-managed-wrapper' marker.

P2: semgrep-diff.sh fallback used 'rev-list HEAD --max-count=50 | tail -1'
which on a single-commit branch returns HEAD itself; --baseline-commit=HEAD
produces an empty diff and silently misses everything. Now: refuse HEAD as
baseline and run a full scan instead so first-push coverage stays honest.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
