### PR TITLE
fix(security): codex audit follow-ups (preserve pre-push.local, baseline correctness)

### DIFF
--- a/.xtrm/skills/default/security-pipeline/scripts/security-bootstrap.sh
+++ b/.xtrm/skills/default/security-pipeline/scripts/security-bootstrap.sh
@@ -202,7 +202,13 @@ else
     cp "$PREPUSH_SRC" "$BASELINE"
     chmod +x "$BASELINE"
     if [ -f "$TARGET/.githooks/pre-push" ] && ! grep -q "security-pipeline-managed-wrapper" "$TARGET/.githooks/pre-push" 2>/dev/null; then
-        # Existing hook present and not yet our wrapper — move it aside
+        # Existing hook present and not yet our wrapper — move it aside.
+        # Preserve any pre-existing pre-push.local first so we never clobber it.
+        if [ -f "$TARGET/.githooks/pre-push.local" ]; then
+            ts=$(date +%s)
+            mv "$TARGET/.githooks/pre-push.local" "$TARGET/.githooks/pre-push.local.bak.$ts"
+            echo "  ↪ existing pre-push.local preserved as pre-push.local.bak.$ts"
+        fi
         mv "$TARGET/.githooks/pre-push" "$TARGET/.githooks/pre-push.local"
         chmod +x "$TARGET/.githooks/pre-push.local"
         echo "  ↪ existing .githooks/pre-push moved to pre-push.local"

--- a/.xtrm/skills/default/security-pipeline/templates/scripts/semgrep-diff.sh
+++ b/.xtrm/skills/default/security-pipeline/templates/scripts/semgrep-diff.sh
@@ -24,22 +24,25 @@ fi
 
 [ -n "$BASE_REF" ] && git fetch "${BASE_REF%%/*}" "${BASE_REF#*/}" --quiet 2>/dev/null || true
 
+SEMGREP_BASELINE_ARGS=()
 if [ -n "$BASE_REF" ]; then
     BASE=$(git merge-base HEAD "$BASE_REF" 2>/dev/null || true)
+    # If merge-base resolves to HEAD (branch tip == upstream), the diff is
+    # legitimately empty — pass --baseline-commit anyway so semgrep produces
+    # an empty result instead of falling back to a full scan.
+    [ -n "$BASE" ] && SEMGREP_BASELINE_ARGS=(--baseline-commit="$BASE")
 fi
-# Final fallback: walk back enough to cover the push. On a single-commit
-# history rev-list returns HEAD itself — using HEAD as baseline produces an
-# empty diff and silently misses everything. Refuse that case and run a
-# full scan instead so first-push coverage stays honest.
-if [ -z "${BASE:-}" ]; then
+# Last-resort fallback only if upstream resolution gave nothing at all.
+# rev-list can equal HEAD on single-commit histories; that would silently
+# scan nothing, so refuse the HEAD-as-baseline case and run a full scan.
+if [ ${#SEMGREP_BASELINE_ARGS[@]} -eq 0 ]; then
     BASE=$(git rev-list HEAD --max-count=50 | tail -1)
-fi
-HEAD_SHA=$(git rev-parse HEAD)
-SEMGREP_BASELINE_ARGS=()
-if [ -n "${BASE:-}" ] && [ "$BASE" != "$HEAD_SHA" ]; then
-    SEMGREP_BASELINE_ARGS=(--baseline-commit="$BASE")
-else
-    echo "[semgrep-diff] no usable baseline (single-commit branch?) — running full scan"
+    HEAD_SHA=$(git rev-parse HEAD)
+    if [ -n "$BASE" ] && [ "$BASE" != "$HEAD_SHA" ]; then
+        SEMGREP_BASELINE_ARGS=(--baseline-commit="$BASE")
+    else
+        echo "[semgrep-diff] no usable baseline (single-commit branch?) — running full scan"
+    fi
 fi
 
 exec semgrep scan \

--- a/scripts/semgrep-diff.sh
+++ b/scripts/semgrep-diff.sh
@@ -24,22 +24,25 @@ fi
 
 [ -n "$BASE_REF" ] && git fetch "${BASE_REF%%/*}" "${BASE_REF#*/}" --quiet 2>/dev/null || true
 
+SEMGREP_BASELINE_ARGS=()
 if [ -n "$BASE_REF" ]; then
     BASE=$(git merge-base HEAD "$BASE_REF" 2>/dev/null || true)
+    # If merge-base resolves to HEAD (branch tip == upstream), the diff is
+    # legitimately empty — pass --baseline-commit anyway so semgrep produces
+    # an empty result instead of falling back to a full scan.
+    [ -n "$BASE" ] && SEMGREP_BASELINE_ARGS=(--baseline-commit="$BASE")
 fi
-# Final fallback: walk back enough to cover the push. On a single-commit
-# history rev-list returns HEAD itself — using HEAD as baseline produces an
-# empty diff and silently misses everything. Refuse that case and run a
-# full scan instead so first-push coverage stays honest.
-if [ -z "${BASE:-}" ]; then
+# Last-resort fallback only if upstream resolution gave nothing at all.
+# rev-list can equal HEAD on single-commit histories; that would silently
+# scan nothing, so refuse the HEAD-as-baseline case and run a full scan.
+if [ ${#SEMGREP_BASELINE_ARGS[@]} -eq 0 ]; then
     BASE=$(git rev-list HEAD --max-count=50 | tail -1)
-fi
-HEAD_SHA=$(git rev-parse HEAD)
-SEMGREP_BASELINE_ARGS=()
-if [ -n "${BASE:-}" ] && [ "$BASE" != "$HEAD_SHA" ]; then
-    SEMGREP_BASELINE_ARGS=(--baseline-commit="$BASE")
-else
-    echo "[semgrep-diff] no usable baseline (single-commit branch?) — running full scan"
+    HEAD_SHA=$(git rev-parse HEAD)
+    if [ -n "$BASE" ] && [ "$BASE" != "$HEAD_SHA" ]; then
+        SEMGREP_BASELINE_ARGS=(--baseline-commit="$BASE")
+    else
+        echo "[semgrep-diff] no usable baseline (single-commit branch?) — running full scan"
+    fi
 fi
 
 exec semgrep scan \


### PR DESCRIPTION
P1: bootstrap mv could clobber existing pre-push.local on second run or
when an operator already maintained one. Now backs up to pre-push.local.bak.$ts.

P1: semgrep-diff.sh dropped --baseline-commit when BASE==HEAD even when
BASE legitimately came from merge-base (branch tip == upstream). That made
no-diff PRs fall back to a full scan and re-flag pre-existing debt. The
HEAD guard is now scoped to the rev-list desperate fallback only.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
