### PR TITLE
fix(security): phase 5 codex follow-ups (e9e/q81/b52)

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -5,7 +5,6 @@
 .beads/
 .specialists/
 .dolt/
-.xtrm/
 .bv/
 .emdash/
 .gitnexus
@@ -13,6 +12,45 @@ data/
 logs/
 grafana/data/
 traefik/logs/
+
+# .xtrm/ runtime + cache, but DO scan the security-pipeline skill source.
+# Blanket .xtrm/ exclusion would hide bugs in scripts we ship to other repos.
+.xtrm/state.json
+.xtrm/statusline-claim
+.xtrm/logs/
+.xtrm/cache/
+.xtrm/config/
+.xtrm/ext-src/
+.xtrm/packages/
+.xtrm/hooks/
+.xtrm/skills/active/
+.xtrm/skills/optional/
+.xtrm/skills/user/
+.xtrm/skills/default/clean-code/
+.xtrm/skills/default/creating-service-skills/
+.xtrm/skills/default/deepwiki/
+.xtrm/skills/default/delegating/
+.xtrm/skills/default/documenting/
+.xtrm/skills/default/find-docs/
+.xtrm/skills/default/find-skills/
+.xtrm/skills/default/github-search/
+.xtrm/skills/default/gitnexus-cli/
+.xtrm/skills/default/gitnexus-debugging/
+.xtrm/skills/default/gitnexus-exploring/
+.xtrm/skills/default/gitnexus-guide/
+.xtrm/skills/default/gitnexus-impact-analysis/
+.xtrm/skills/default/gitnexus-refactoring/
+.xtrm/skills/default/last30days/
+.xtrm/skills/default/quality-gates/
+.xtrm/skills/default/scoping-service-skills/
+.xtrm/skills/default/session-close-report/
+.xtrm/skills/default/skill-creator/
+.xtrm/skills/default/sync-docs/
+.xtrm/skills/default/updating-service-skills/
+.xtrm/skills/default/using-quality-gates/
+.xtrm/skills/default/using-specialists-v3/
+.xtrm/skills/default/using-xtrm/
+# (security-pipeline left in scope — its scripts ship into target repos)
 
 # Test fixtures and snapshots — false positive heavy
 **/test_fixtures/

--- a/.xtrm/skills/default/security-pipeline/scripts/security-bootstrap.sh
+++ b/.xtrm/skills/default/security-pipeline/scripts/security-bootstrap.sh
@@ -35,8 +35,14 @@ echo "── Target: $TARGET ($SLUG) ──"
 
 # ── 1. Detect ecosystems for dependabot.yml ───────────────────────────────
 ECOSYSTEMS=()
-[ -f requirements.txt ] || find . -maxdepth 3 -name 'requirements*.txt' -not -path '*/node_modules/*' -print -quit | grep -q . && ECOSYSTEMS+=("pip")
-[ -f pyproject.toml ] && ECOSYSTEMS+=("pip-pyproject")
+# pip ecosystem covers BOTH requirements*.txt and pyproject.toml — emit a
+# single 'pip' entry to avoid duplicate dependabot blocks for /.
+HAS_PIP=0
+if [ -f requirements.txt ] || find . -maxdepth 3 -name 'requirements*.txt' -not -path '*/node_modules/*' -print -quit | grep -q .; then
+    HAS_PIP=1
+fi
+[ -f pyproject.toml ] && HAS_PIP=1
+[ "$HAS_PIP" = "1" ] && ECOSYSTEMS+=("pip")
 [ -f package.json ] && [ "$(cat package.json | python3 -c 'import json,sys;d=json.load(sys.stdin);print(len(d))' 2>/dev/null)" -gt 1 ] && ECOSYSTEMS+=("npm")
 find . -maxdepth 5 -name 'Dockerfile' -not -path '*/node_modules/*' -print -quit | grep -q . && ECOSYSTEMS+=("docker")
 [ -f go.mod ] && ECOSYSTEMS+=("gomod")
@@ -100,7 +106,7 @@ else
         echo "updates:"
         for eco in "${ECOSYSTEMS[@]}"; do
             case "$eco" in
-                pip|pip-pyproject)
+                pip)
                     cat <<'EOF'
   - package-ecosystem: pip
     directory: /

--- a/.xtrm/skills/default/security-pipeline/templates/.semgrepignore
+++ b/.xtrm/skills/default/security-pipeline/templates/.semgrepignore
@@ -5,7 +5,6 @@
 .beads/
 .specialists/
 .dolt/
-.xtrm/
 .bv/
 .emdash/
 .gitnexus
@@ -13,6 +12,45 @@ data/
 logs/
 grafana/data/
 traefik/logs/
+
+# .xtrm/ runtime + cache, but DO scan the security-pipeline skill source.
+# Blanket .xtrm/ exclusion would hide bugs in scripts we ship to other repos.
+.xtrm/state.json
+.xtrm/statusline-claim
+.xtrm/logs/
+.xtrm/cache/
+.xtrm/config/
+.xtrm/ext-src/
+.xtrm/packages/
+.xtrm/hooks/
+.xtrm/skills/active/
+.xtrm/skills/optional/
+.xtrm/skills/user/
+.xtrm/skills/default/clean-code/
+.xtrm/skills/default/creating-service-skills/
+.xtrm/skills/default/deepwiki/
+.xtrm/skills/default/delegating/
+.xtrm/skills/default/documenting/
+.xtrm/skills/default/find-docs/
+.xtrm/skills/default/find-skills/
+.xtrm/skills/default/github-search/
+.xtrm/skills/default/gitnexus-cli/
+.xtrm/skills/default/gitnexus-debugging/
+.xtrm/skills/default/gitnexus-exploring/
+.xtrm/skills/default/gitnexus-guide/
+.xtrm/skills/default/gitnexus-impact-analysis/
+.xtrm/skills/default/gitnexus-refactoring/
+.xtrm/skills/default/last30days/
+.xtrm/skills/default/quality-gates/
+.xtrm/skills/default/scoping-service-skills/
+.xtrm/skills/default/session-close-report/
+.xtrm/skills/default/skill-creator/
+.xtrm/skills/default/sync-docs/
+.xtrm/skills/default/updating-service-skills/
+.xtrm/skills/default/using-quality-gates/
+.xtrm/skills/default/using-specialists-v3/
+.xtrm/skills/default/using-xtrm/
+# (security-pipeline left in scope — its scripts ship into target repos)
 
 # Test fixtures and snapshots — false positive heavy
 **/test_fixtures/

--- a/.xtrm/skills/default/security-pipeline/templates/scripts/semgrep-diff.sh
+++ b/.xtrm/skills/default/security-pipeline/templates/scripts/semgrep-diff.sh
@@ -10,15 +10,27 @@ if ! command -v semgrep >/dev/null; then
     exit 0
 fi
 
-# Derive base ref dynamically: prefer the branch's tracked upstream, fall back
-# to common default branches, finally to HEAD~N where N covers the whole push.
+# Derive base ref dynamically. Order:
+#   1. branch's tracked upstream ('@{u}') — most reliable
+#   2. common default branches if their *remote* version exists (origin/*)
+#   3. local default branches IF different from current branch
+# We refuse to use the current branch as its own baseline because then
+# merge-base resolves to HEAD and --baseline-commit=HEAD silently scans
+# nothing on every push.
+HEAD_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+HEAD_SHA=$(git rev-parse HEAD)
+
 upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)
+BASE_REF=""
 if [ -n "$upstream" ]; then
     BASE_REF="$upstream"
 else
-    BASE_REF=""
     for cand in origin/main origin/master main master; do
-        git rev-parse --verify "$cand" >/dev/null 2>&1 && BASE_REF="$cand" && break
+        git rev-parse --verify "$cand" >/dev/null 2>&1 || continue
+        # Skip a local-branch candidate that IS the current branch
+        [ "$cand" = "$HEAD_BRANCH" ] && continue
+        BASE_REF="$cand"
+        break
     done
 fi
 
@@ -27,21 +39,19 @@ fi
 SEMGREP_BASELINE_ARGS=()
 if [ -n "$BASE_REF" ]; then
     BASE=$(git merge-base HEAD "$BASE_REF" 2>/dev/null || true)
-    # If merge-base resolves to HEAD (branch tip == upstream), the diff is
-    # legitimately empty — pass --baseline-commit anyway so semgrep produces
-    # an empty result instead of falling back to a full scan.
+    # merge-base==HEAD here means branch is at upstream tip — legitimate empty
+    # diff. Pass --baseline-commit so semgrep produces an empty result rather
+    # than falling back to a full scan.
     [ -n "$BASE" ] && SEMGREP_BASELINE_ARGS=(--baseline-commit="$BASE")
 fi
-# Last-resort fallback only if upstream resolution gave nothing at all.
-# rev-list can equal HEAD on single-commit histories; that would silently
-# scan nothing, so refuse the HEAD-as-baseline case and run a full scan.
+# Last-resort: no upstream resolved at all. rev-list can equal HEAD on single
+# -commit histories; reject and full-scan in that case.
 if [ ${#SEMGREP_BASELINE_ARGS[@]} -eq 0 ]; then
     BASE=$(git rev-list HEAD --max-count=50 | tail -1)
-    HEAD_SHA=$(git rev-parse HEAD)
     if [ -n "$BASE" ] && [ "$BASE" != "$HEAD_SHA" ]; then
         SEMGREP_BASELINE_ARGS=(--baseline-commit="$BASE")
     else
-        echo "[semgrep-diff] no usable baseline (single-commit branch?) — running full scan"
+        echo "[semgrep-diff] no usable baseline (no upstream, single-commit branch, or pushing default branch directly) — running full scan"
     fi
 fi
 

--- a/scripts/semgrep-diff.sh
+++ b/scripts/semgrep-diff.sh
@@ -10,15 +10,27 @@ if ! command -v semgrep >/dev/null; then
     exit 0
 fi
 
-# Derive base ref dynamically: prefer the branch's tracked upstream, fall back
-# to common default branches, finally to HEAD~N where N covers the whole push.
+# Derive base ref dynamically. Order:
+#   1. branch's tracked upstream ('@{u}') — most reliable
+#   2. common default branches if their *remote* version exists (origin/*)
+#   3. local default branches IF different from current branch
+# We refuse to use the current branch as its own baseline because then
+# merge-base resolves to HEAD and --baseline-commit=HEAD silently scans
+# nothing on every push.
+HEAD_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+HEAD_SHA=$(git rev-parse HEAD)
+
 upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)
+BASE_REF=""
 if [ -n "$upstream" ]; then
     BASE_REF="$upstream"
 else
-    BASE_REF=""
     for cand in origin/main origin/master main master; do
-        git rev-parse --verify "$cand" >/dev/null 2>&1 && BASE_REF="$cand" && break
+        git rev-parse --verify "$cand" >/dev/null 2>&1 || continue
+        # Skip a local-branch candidate that IS the current branch
+        [ "$cand" = "$HEAD_BRANCH" ] && continue
+        BASE_REF="$cand"
+        break
     done
 fi
 
@@ -27,21 +39,19 @@ fi
 SEMGREP_BASELINE_ARGS=()
 if [ -n "$BASE_REF" ]; then
     BASE=$(git merge-base HEAD "$BASE_REF" 2>/dev/null || true)
-    # If merge-base resolves to HEAD (branch tip == upstream), the diff is
-    # legitimately empty — pass --baseline-commit anyway so semgrep produces
-    # an empty result instead of falling back to a full scan.
+    # merge-base==HEAD here means branch is at upstream tip — legitimate empty
+    # diff. Pass --baseline-commit so semgrep produces an empty result rather
+    # than falling back to a full scan.
     [ -n "$BASE" ] && SEMGREP_BASELINE_ARGS=(--baseline-commit="$BASE")
 fi
-# Last-resort fallback only if upstream resolution gave nothing at all.
-# rev-list can equal HEAD on single-commit histories; that would silently
-# scan nothing, so refuse the HEAD-as-baseline case and run a full scan.
+# Last-resort: no upstream resolved at all. rev-list can equal HEAD on single
+# -commit histories; reject and full-scan in that case.
 if [ ${#SEMGREP_BASELINE_ARGS[@]} -eq 0 ]; then
     BASE=$(git rev-list HEAD --max-count=50 | tail -1)
-    HEAD_SHA=$(git rev-parse HEAD)
     if [ -n "$BASE" ] && [ "$BASE" != "$HEAD_SHA" ]; then
         SEMGREP_BASELINE_ARGS=(--baseline-commit="$BASE")
     else
-        echo "[semgrep-diff] no usable baseline (single-commit branch?) — running full scan"
+        echo "[semgrep-diff] no usable baseline (no upstream, single-commit branch, or pushing default branch directly) — running full scan"
     fi
 fi
 


### PR DESCRIPTION
infra-e9e (P3): semgrep-diff would silently scan an empty diff when BASE_REF
fell back to a local branch name equal to the current HEAD branch (e.g.
running on 'main' without upstream → BASE_REF=main → merge-base=HEAD).
Fix: skip a local-branch candidate that equals current branch name.

infra-q81 (P3): .semgrepignore blanket-excluded .xtrm/, hiding the
security-pipeline skill source from SAST. Replaced with per-skill
exclusions; .xtrm/skills/default/security-pipeline/ is now scanned.

infra-b52 (P4): bootstrap script tracked pip and pip-pyproject as two
distinct ecosystems but both generated identical dependabot blocks for /,
producing invalid duplicate entries. Now: single 'pip' entry covers any
combination of requirements*.txt and pyproject.toml.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
