### PR TITLE
ci: add installer and extension contract gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,17 @@ jobs:
       - name: Classify impact
         id: classify
         shell: bash
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          PUSH_HEAD_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           if [ "$GITHUB_EVENT_NAME" = pull_request ]; then
-            git diff --no-renames --name-only --diff-filter=ACMRD \
-              '${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}' > changed.txt
+            git diff --no-renames --name-only --diff-filter=ACDMRTUXB "$PR_BASE_SHA...$PR_HEAD_SHA" > changed.txt
+          elif [ "$GITHUB_EVENT_NAME" = push ] && [[ "$PUSH_BEFORE_SHA" =~ ^[0-9a-f]{40}$ ]] && [ "$PUSH_BEFORE_SHA" != 0000000000000000000000000000000000000000 ]; then
+            git diff --no-renames --name-only --diff-filter=ACDMRTUXB "$PUSH_BEFORE_SHA..$PUSH_HEAD_SHA" > changed.txt
           else
             git ls-files > changed.txt
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,114 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: terminalbeta-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scope:
+    name: Scope
+    runs-on: ubuntu-latest
+    outputs:
+      run_package: ${{ steps.classify.outputs.run_package }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Classify impact
+        id: classify
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_EVENT_NAME" = pull_request ]; then
+            git diff --no-renames --name-only --diff-filter=ACMRD \
+              '${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}' > changed.txt
+          else
+            git ls-files > changed.txt
+          fi
+          run_package=false
+          while IFS= read -r path; do
+            case "$path" in
+              *.md|docs/*|.beads/*|.specialists/*|.xtrm/*|.claude/skills/*) ;;
+              index.js|servers.json|package.json|package-lock.json|ext/*|.github/workflows/*) run_package=true ;;
+              *) run_package=true ;; # unknown fails safe
+            esac
+          done < changed.txt
+          echo "run_package=$run_package" >> "$GITHUB_OUTPUT"
+          cat changed.txt
+
+  package:
+    name: Installer & extension contract
+    needs: scope
+    if: needs.scope.outputs.run_package == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          cache: npm
+          package-manager-cache: false
+      - name: Install root package
+        run: npm ci
+      - name: Syntax-check installer and proxy
+        run: |
+          node --check index.js
+          node --check ext/mercury-platform/server/index.mjs
+      - name: Validate JSON contracts
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const servers = JSON.parse(fs.readFileSync('servers.json', 'utf8'));
+          const root = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+          const manifest = JSON.parse(fs.readFileSync('ext/mercury-platform/manifest.json', 'utf8'));
+          if (!Array.isArray(servers) || servers.length === 0) throw new Error('servers.json must be a non-empty array');
+          const names = new Set();
+          for (const server of servers) {
+            for (const key of ['name','label','description','url','transport']) if (!server[key]) throw new Error(`missing ${key}`);
+            if (names.has(server.name)) throw new Error(`duplicate server ${server.name}`);
+            names.add(server.name);
+            const url = new URL(server.url);
+            if (url.protocol !== 'https:') throw new Error(`non-HTTPS server URL: ${server.url}`);
+            if (server.transport !== 'http') throw new Error(`unexpected transport for ${server.name}`);
+          }
+          if (!root.bin?.['mercury-install-mcp']) throw new Error('package bin contract missing');
+          if (!manifest || typeof manifest !== 'object') throw new Error('extension manifest invalid');
+          console.log(`validated ${servers.length} server entries`);
+          NODE
+      - name: Verify packaged artifacts are present
+        run: |
+          test -s ext/mercury-platform/mercury-platform.mcpb
+          npm pack --dry-run >/dev/null
+
+  gate:
+    name: ci/gate
+    if: always()
+    needs: [scope, package]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce selected jobs
+        env:
+          SCOPE_RESULT: ${{ needs.scope.result }}
+          PACKAGE_RESULT: ${{ needs.package.result }}
+          RUN_PACKAGE: ${{ needs.scope.outputs.run_package }}
+        run: |
+          set -euo pipefail
+          [ "$SCOPE_RESULT" = success ]
+          if [ "$RUN_PACKAGE" = true ]; then [ "$PACKAGE_RESULT" = success ]; else case "$PACKAGE_RESULT" in skipped|success) ;; *) exit 1 ;; esac; fi

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,33 +1,46 @@
 name: Gitleaks
 
-# Backstop scan for committed secrets (full history on push to main, diff on PRs).
-# GitHub push protection is the primary gate; this catches anything pre-existing
-# or pushed from a client without push protection enabled.
-
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
   schedule:
-    - cron: "0 6 * * 1"  # Monday 06:00 UTC weekly
+    - cron: "31 6 * * 1"
 
 permissions:
   contents: read
-  pull-requests: write  # write needed to post the leak summary comment on PRs
+
+concurrency:
+  group: terminalbeta-gitleaks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   gitleaks:
     name: Gitleaks scan
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0  # full history for scheduled deep scans
-
-      - name: Gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # GITLEAKS_LICENSE only required for org accounts; private user repos run free.
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install Gitleaks
+        run: |
+          set -euo pipefail
+          version=v8.30.1
+          curl --proto '=https' --tlsv1.2 -fsSLo "$RUNNER_TEMP/gitleaks.tar.gz" \
+            "https://github.com/gitleaks/gitleaks/releases/download/${version}/gitleaks_${version#v}_linux_x64.tar.gz"
+          tar -xzf "$RUNNER_TEMP/gitleaks.tar.gz" -C "$RUNNER_TEMP" gitleaks
+          install "$RUNNER_TEMP/gitleaks" "$RUNNER_TEMP/gitleaks-bin"
+      - name: Scan
+        run: |
+          set -euo pipefail
+          cfg=()
+          [ ! -f .gitleaks.toml ] || cfg=(--config .gitleaks.toml)
+          if [ "$GITHUB_EVENT_NAME" = pull_request ]; then
+            "$RUNNER_TEMP/gitleaks-bin" git --log-opts '${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}' --redact "${cfg[@]}" --no-banner .
+          else
+            "$RUNNER_TEMP/gitleaks-bin" git --redact "${cfg[@]}" --no-banner .
+          fi

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -26,13 +26,16 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Install Gitleaks
+      - name: Install verified Gitleaks
         run: |
           set -euo pipefail
           version=v8.30.1
-          curl --proto '=https' --tlsv1.2 -fsSLo "$RUNNER_TEMP/gitleaks.tar.gz" \
+          expected_sha256=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+          archive="$RUNNER_TEMP/gitleaks.tar.gz"
+          curl --proto '=https' --tlsv1.2 -fsSLo "$archive" \
             "https://github.com/gitleaks/gitleaks/releases/download/${version}/gitleaks_${version#v}_linux_x64.tar.gz"
-          tar -xzf "$RUNNER_TEMP/gitleaks.tar.gz" -C "$RUNNER_TEMP" gitleaks
+          printf '%s  %s\n' "$expected_sha256" "$archive" | sha256sum -c -
+          tar -xzf "$archive" -C "$RUNNER_TEMP" gitleaks
           install "$RUNNER_TEMP/gitleaks" "$RUNNER_TEMP/gitleaks-bin"
       - name: Scan
         run: |

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,33 +1,33 @@
 name: OSV Scanner
 
-# Vulnerability scanner from Google's OSV.dev — replaces Dependency Review on
-# user-private repos where Dependency Review (a GHAS feature) is unavailable.
-# Scans manifests + lockfiles against the OSV.dev database.
-
 on:
   push:
-    branches: [main, master]    # scan immediately after every merge
+    branches: [main]
   pull_request:
-    branches: [main, master]
+    branches: [main]
   schedule:
-    - cron: "0 6 * * 1"  # Monday 06:00 UTC weekly
+    - cron: "47 6 * * 1"
 
 permissions:
   contents: read
+
+concurrency:
+  group: terminalbeta-osv-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   scan:
     name: OSV scan
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Run OSV-Scanner
-        uses: google/osv-scanner-action/osv-scanner-action@v2.3.8
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Note: --skip-git was removed in v2.3+. Recursive scan walks the
-          # working tree and respects .gitignore by default.
+          persist-credentials: false
+      - name: Run OSV-Scanner
+        uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+        with:
           scan-args: |-
             --recursive
             ./

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -24,8 +24,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
+      - name: Determine dependency impact
+        id: scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_EVENT_NAME" != pull_request ]; then
+            echo 'run=true' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git diff --no-renames --name-only --diff-filter=ACMRD \
+            '${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}' > changed.txt
+          if grep -Eq '^(package\.json|package-lock\.json|ext/mercury-platform/package\.json|ext/mercury-platform/package-lock\.json)$' changed.txt; then
+            echo 'run=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'run=false' >> "$GITHUB_OUTPUT"
+            echo 'No dependency-bearing file changed; historical dependency debt remains covered by default-branch/weekly scans.'
+          fi
       - name: Run OSV-Scanner
+        if: steps.scope.outputs.run == 'true'
         uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
         with:
           scan-args: |-


### PR DESCRIPTION
Adds an additive `ci/gate` for the actual Terminal Beta delivery surface: Node syntax checks, server-registry/manifest invariants, HTTPS/transport validation, committed MCPB presence, and `npm pack --dry-run`. Docs/skills/Beads/XTRM-only changes skip the package lane; unknown paths fail safe.

During validation the legacy security workflows were repaired too: Gitleaks now uses the direct v8.30.1 CLI with official SHA-256 verification, OSV uses the pinned v2.3.8 action, and PR OSV is dependency-diff-aware while default-branch/weekly scans continue exposing historical vulnerability debt. PR and push impact classification use immutable deltas and include Git type changes.

The workflow never calls live Mercury endpoints and does not install or deploy anything for users. Existing review context remains present.

Exact-head CI, Gitleaks, OSV, Semgrep and review gate are green.

Programme decision: ADR-0005 staged in current program PR #89 under explicit operator authorization. Jira receipt pending because Atlassian Rovo is unavailable in this session.