### PR TITLE
security(ci): pin Semgrep workflow supply chain

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -22,12 +22,14 @@ jobs:
     name: Semgrep scan
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep
+      # Digest observed from successful Mercury CI for Semgrep 1.171.0.
+      image: semgrep/semgrep@sha256:bdf7013b2c3634a487671158da77c554f531742326b543a9464d2adf6c433ac8
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0  # full history for baseline diff
+          persist-credentials: false
 
       - name: Semgrep CI
         run: semgrep ci


### PR DESCRIPTION
Bounded ADR-0005 hardening of Terminal Beta's remaining live mutable Semgrep workflow.

- pin `actions/checkout` to the verified v7.0.1 commit SHA;
- disable checkout credential persistence;
- pin the Semgrep 1.171.0 container digest already proven in Mercury CI;
- preserve triggers, rules and runner placement unchanged.

Terminal Beta's Gitleaks and delta-aware OSV workflows are already pinned/verified and are not changed here. No installer/package contract, ruleset, runner, service, secret or production state is changed.

Programme authority: ADR-0005 (`c9217101073743748d50f42cf504b19be5d3d04e`). Jira portfolio receipt remains pending because Atlassian Rovo is unavailable in this session.